### PR TITLE
Upgrade to Spark 2.4.0 & Scala 2.12.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ local.properties
 .project
 .scala_dependencies
 .worksheet
+
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
-      scalaVersion := "2.11.12",
+      scalaVersion := "2.12.7",
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ lazy val root = (project in file(".")).
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.2",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.2",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.0",
     libraryDependencies += scalaTest % Test
   )
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.4
+sbt.version=1.2.6


### PR DESCRIPTION
Resolves #4 

The issue could not be resolved since Spark 2.3.x dependent on  Scala 2.11 which is depend on old JLine which is incompatible to new curses library.
Now, from the Spark 2.4.0, Spark can be compiled on Scala 2.12 and this resolves the issue.