### PR TITLE
Update for Spark 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,5 @@ local.properties
 .project
 .scala_dependencies
 .worksheet
+
+.idea

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
-      scalaVersion := "2.11.12",
+      scalaVersion := "2.12.7",
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ lazy val root = (project in file(".")).
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.1",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.1",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.2",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.2",
     libraryDependencies += scalaTest % Test
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -8,8 +8,8 @@ lazy val root = (project in file(".")).
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.2",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.2",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.0",
     libraryDependencies += scalaTest % Test
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,12 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
-      scalaVersion := "2.12.7",
+      scalaVersion := "2.12.12",
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.4.0",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.4.0",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % "3.0.0",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "3.0.0",
     libraryDependencies += scalaTest % Test
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -4,12 +4,12 @@ lazy val root = (project in file(".")).
   settings(
     inThisBuild(List(
       organization := "com.example",
-      scalaVersion := "2.11.11",
+      scalaVersion := "2.11.12",
       version      := "0.1.0-SNAPSHOT"
     )),
     name := "SparkExample",
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.1.0",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.1.0",
+    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.1",
+    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.1",
     libraryDependencies += scalaTest % Test
   )
 

--- a/build.sbt
+++ b/build.sbt
@@ -14,14 +14,16 @@ lazy val root = (project in file(".")).
   )
 
 initialCommands in console := """
+  import org.apache.log4j.{Level, Logger}
   import org.apache.spark.sql.SparkSession
   import org.apache.spark.sql.functions._
-  val spark = SparkSession.builder()
-    .master("local")
+  Logger.getLogger("org.apache.spark").setLevel(Level.WARN)
+  val spark = SparkSession.builder
+    .master("local[*]")
     .appName("spark-shell")
-    .getOrCreate()
+    .getOrCreate
   import spark.implicits._
-  val sc = spark.sparkContext
+  lazy val sc = spark.sparkContext
 """
 
-cleanupCommands in console := "spark.stop()"
+cleanupCommands in console := "if (spark != null) spark.stop()"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.1"
+  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,5 +1,5 @@
 import sbt._
 
 object Dependencies {
-  lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.0.5"
+  lazy val scalaTest = "org.scalatest" %% "scalatest-funspec" % "3.2.0"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.6
+sbt.version=1.3.13

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.1

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.4
+sbt.version=1.2.6

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.4

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
 // to create Eclipse project by "sbt eclipse"
 // From: https://github.com/typesafehub/sbteclipse
-addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.1.0")
+addSbtPlugin("com.typesafe.sbteclipse" % "sbteclipse-plugin" % "5.2.4")
 

--- a/src/test/scala/example/ShakespeareSpec.scala
+++ b/src/test/scala/example/ShakespeareSpec.scala
@@ -1,20 +1,25 @@
 package example
 
+import org.apache.log4j.{Level, Logger}
+import org.apache.spark.sql.SparkSession
 import org.scalatest._
 import funspec.AnyFunSpec
-import org.apache.spark.sql.SparkSession
 
-class ShakespeareSpec extends AnyFunSpec with BeforeAndAfter {
-  private var spark: SparkSession = _
-  before {
-    spark = SparkSession.builder
-      .master("local")
-      .appName("ShakespeareSpec")
-      .getOrCreate
+class ShakespeareSpec extends AnyFunSpec with BeforeAndAfterAll {
+  lazy val spark: SparkSession = SparkSession.builder
+    .master("local[*]")
+    .appName(this.getClass.getName)
+    .getOrCreate
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    Logger.getLogger("org.apache.spark").setLevel(Level.WARN)
+    spark
   }
 
-  after {
+  override def afterAll(): Unit = {
     if (spark != null) spark.stop()
+    super.afterAll()
   }
 
   describe("Shakespeare.df") {

--- a/src/test/scala/example/ShakespeareSpec.scala
+++ b/src/test/scala/example/ShakespeareSpec.scala
@@ -1,9 +1,10 @@
 package example
 
 import org.scalatest._
+import funspec.AnyFunSpec
 import org.apache.spark.sql.SparkSession
 
-class ShakespeareSpec extends FunSpec with BeforeAndAfter {
+class ShakespeareSpec extends AnyFunSpec with BeforeAndAfter {
   private var spark: SparkSession = _
   before {
     spark = SparkSession.builder


### PR DESCRIPTION
Upgrade packages
* Spark 3.0.0
 * Scala 2.12.12: Since spark 3.x requires Scala 2.12.x, though the latest version of Scala is 2.13.x
 * Sbt 1.1.3
 * Scalatest 3.2.0
 * sbteclipse-plugin 5.2.4

Enhancements
 * Remove verbose messages
 * Handle Sparksession in more detail